### PR TITLE
fix: handle empty array output

### DIFF
--- a/src/ImmutableBase.php
+++ b/src/ImmutableBase.php
@@ -204,6 +204,7 @@ abstract class ImmutableBase implements JsonSerializable
             $value = $property->getValue($this);
             $key = $property->getName();
             if (is_array($value)) {
+                $properties[$key] = [];
                 foreach ($value as $v) {
                     if (is_object($v) && method_exists($v, 'toArray')) {
                         $properties[$key][] = $v->toArray();


### PR DESCRIPTION
### Description

If an empty array is provided to tags, calling toArray() results in the tags property being missing.

### Changes

Initialize properties array in walkProperties when the property is an array, preventing undefined index errors.

Ensure object arrays are properly converted into array format, improving data processing stability.

### Before / After Example
```
#[DataTransferObject]
final class UserProfileResponse extends ImmutableBase
{
    public readonly int $id;
    public readonly array $tags;
}

$dto = new UserProfileResponse([
  'id' => 1,
  'tags' => []
]);

print_r($dto->toArray());

Before (Buggy Behavior)
Array
(
    [id] => 1
    // [tags] is missing
)

After (Fixed Behavior)
Array
(
    [id] => 1
    [tags] => []
)
```