### PR TITLE
docs: add v4.0.0 CHANGELOG entry based on temp-main delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## [v4.0.0] - 2026-02-23
+
+### ⚠️ Breaking Changes
+
+- Raised the minimum supported PHP version to **8.4**.
+- Removed the legacy mode attributes `#[DataTransferObject]`, `#[ValueObject]`, and `#[Entity]`; class behavior is now defined by extending object base classes directly.
+- Removed the `Entity` base class from `Objects\*` APIs.
+- Reworked the exception structure into domain-specific trees (`Definition*`, `Initialization*`, `Validation*`) and removed several legacy exception classes.
+
+### Added
+
+- Added new behavior attributes: `#[Strict]`, `#[Lax]`, `#[SkipOnNull]`, `#[KeepOnNull]`, `#[ValidateFromSelf]`, and `#[Spec]`.
+- Added a dedicated `Interfaces\SingleValueObject` contract and expanded `Objects\SingleValueObject` helpers (including single-value conversion and serialization ergonomics).
+- Added CLI toolchains:
+  - `cacher` for metadata cache generation.
+  - `writer` with Markdown and Mermaid outputs for object-structure documentation.
+- Added new benchmark suites and fixtures to cover nested DTOs, wide payload scenarios, VO/SVO usage, and enum-heavy paths.
+- Added extensive attack/edge-case test scenarios (deep nesting, forbidden types, enum boundaries, nullable array-of behavior, and null-output controls).
+
+### Changed
+
+- Refactored core metadata/runtime management in `ImmutableBase` with centralized static status and richer typed metadata definitions.
+- Strengthened type-resolution and object-construction validation flows, especially around `ArrayOf`, enum conversion, and nested immutable object mutation by path.
+- Updated CI/test layout and project documentation to reflect the new 4.x object model and validation semantics.
+
 ## [v3.1.3] - 2025-12-14
 
 ### Changed


### PR DESCRIPTION
### Motivation
- 紀錄 `temp` 分支相較於 `main` 的差異，並以既有 `CHANGELOG.md` 風格新增 `v4.0.0` 條目，說明重要破壞性變更、加入的新功能與架構調整。

### Description
- 在 `CHANGELOG.md` 最上方新增 `## [v4.0.0] - 2026-02-23` 區段，摘要列出主要內容包括破壞性變更（最低 PHP 提升至 `8.4`、移除舊版 mode attributes、移除 `Entity` base class、例外樹重構）、新增項目（`#[Strict]`, `#[Lax]`, `#[SkipOnNull]`, `#[KeepOnNull]`, `#[ValidateFromSelf]`, `#[Spec]`、`Interfaces\SingleValueObject` 與 `Objects\SingleValueObject` 強化、以及 CLI 工具 `cacher` 與 `writer`）、新增 benchmark 與攻擊/邊界測試情境，以及核心 metadata/runtime 的重構摘要。

### Testing
- 無自動化測試執行；此 PR 為文件更新（`CHANGELOG.md`）且已透過檔案差異檢視確認新增內容正確。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c14217120832b8875e65b4e7c4acc)